### PR TITLE
Add system design scaffold: GenAI, Classical, ML cases + template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# Hands-OnDataScience
+# Grokking System Designs
+
+Real-world system design cases and patterns across three domains.
+
+> Theory notes live in Obsidian. This repo = examples, cases, tradeoffs.
+
+---
+
+## Domains
+
+### [Classical Systems](./classical/)
+Traditional distributed systems — scalability, availability, consistency.
+
+| Cases | Patterns |
+|---|---|
+| [URL Shortener](./classical/cases/url-shortener/) | [Rate Limiting](./classical/patterns/rate-limiting/) |
+| [Twitter Feed](./classical/cases/twitter-feed/) | [Caching](./classical/patterns/caching/) |
+| [Uber](./classical/cases/uber/) | [Consistent Hashing](./classical/patterns/consistent-hashing/) |
+
+---
+
+### [ML Systems](./ml-systems/)
+ML infra and pipelines — data freshness, training/serving skew, latency vs accuracy.
+
+| Cases | Patterns |
+|---|---|
+| [Recommendation Engine](./ml-systems/cases/recommendation-engine/) | [Feature Store](./ml-systems/patterns/feature-store/) |
+| [Fraud Detection](./ml-systems/cases/fraud-detection/) | [Model Serving](./ml-systems/patterns/model-serving/) |
+| [Search Ranking](./ml-systems/cases/search-ranking/) | [Training Pipeline](./ml-systems/patterns/training-pipeline/) |
+
+---
+
+### [GenAI Systems](./genai-systems/)
+LLM-native architectures — context windows, cost, hallucination, eval.
+
+| Cases | Patterns |
+|---|---|
+| [RAG Pipeline](./genai-systems/cases/rag-pipeline/) | [Prompt Caching](./genai-systems/patterns/prompt-caching/) |
+| [AI Agent](./genai-systems/cases/ai-agent/) | [Vector Search](./genai-systems/patterns/vector-search/) |
+| [LLM Gateway](./genai-systems/cases/llm-gateway/) | [Evaluation](./genai-systems/patterns/evaluation/) |
+
+---
+
+## Case Template
+
+Each case follows this structure:
+- **Problem** — what to design, scale requirements
+- **Requirements** — functional + non-functional
+- **Design** — components, data flow, key decisions
+- **Tradeoffs** — what was sacrificed, alternatives considered
+- **Patterns used** — links back to `/patterns/`
+- **Interview tips** — what interviewers look for

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,0 +1,188 @@
+# [System Name]
+
+One-line description of what the system does.
+
+---
+
+## Requirements
+
+### Functional Requirements
+- 
+- 
+- 
+
+### Non-Functional Requirements
+- Latency: 
+- Availability: 
+- Consistency: 
+- Security & Privacy: 
+- Scalability: 
+
+### Out of Scope
+- 
+- 
+
+---
+
+## Back-of-Envelope Estimation
+
+### Traffic Estimation
+| Metric | Value |
+|---|---|
+| DAU / MAU | |
+| Reads/sec | |
+| Writes/sec | |
+
+### Storage Estimation
+| Metric | Value |
+|---|---|
+| Record size | |
+| Records/day | |
+| Storage (1yr) | |
+| Storage (5yr) | |
+
+### Memory Estimation
+| Metric | Value |
+|---|---|
+| Cache size | |
+| Vector index size | |
+
+### Bandwidth Estimation
+| Metric | Value |
+|---|---|
+| Ingress/sec | |
+| Egress/sec | |
+
+### Cost Estimation *(GenAI-specific)*
+| Metric | Value |
+|---|---|
+| Tokens/day | |
+| Cost/day | |
+
+---
+
+## High-Level Design
+
+### Architecture Style
+> e.g. Microservices / Event-driven / Serverless / Monolith / Hybrid
+> Justify the choice in 1-2 lines.
+
+### Architecture Diagram
+```
+Component A → Component B → Component C
+                  ↓
+            Component D
+```
+
+### Core Components
+| Component | Responsibility |
+|---|---|
+| | |
+
+### Data Flow
+1. 
+2. 
+3. 
+
+### Key Design Decisions
+- **Decision 1:** Rationale
+- **Decision 2:** Rationale
+- **Model Selection *(GenAI)*:** Which model, why
+
+---
+
+## Low-Level Design
+
+### Data Models
+```
+Table / Document / Schema name:
+  field_name   TYPE   notes
+```
+
+### API Design
+```
+POST /endpoint
+Request:  { }
+Response: { }
+```
+
+### Component Deep-Dives
+#### Component Name
+Internal logic, data structures, concurrency considerations.
+
+#### Guardrails / Safety Layer *(GenAI-specific)*
+Input validation, output filtering, PII scrubbing, content moderation.
+
+### Algorithms & Strategies
+- **Chunking strategy *(RAG)*:** 
+- **Routing logic:** 
+- **Caching strategy:** 
+- **Prompt design *(GenAI)*:** 
+
+### Security Design
+- AuthN/AuthZ: 
+- Encryption at rest: 
+- Encryption in transit: 
+- Secrets management: 
+- PII handling: 
+
+---
+
+## Observability
+
+### Metrics
+| Metric | Type | Alert threshold |
+|---|---|---|
+| Request latency (p99) | Histogram | |
+| Error rate | Counter | |
+| Cache hit rate | Gauge | |
+
+### Logging
+- Log level strategy (INFO / WARN / ERROR)
+- Structured logging fields: request_id, tenant_id, latency, status
+- What NOT to log: PII, raw prompts (configurable)
+
+### Tracing
+- Distributed trace across: [list components]
+- Trace sampling rate: 
+
+### Alerting
+| Alert | Threshold | Action |
+|---|---|---|
+| High error rate | >1% for 5min | Page on-call |
+| Latency spike | p99 > Xms | Page on-call |
+
+---
+
+## Tradeoffs
+
+| Decision | Chose | Sacrificed |
+|---|---|---|
+| | | |
+| | | |
+
+---
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| | | |
+| | | |
+
+---
+
+## Feedback Loop & Improvements *(GenAI-specific)*
+- How user feedback is captured (thumbs up/down, corrections)
+- How feedback feeds back into system (prompt tuning, retrieval improvement, fine-tuning)
+- Eval cadence: automated regression on golden set per deploy
+
+---
+
+## Interview Tips
+
+### What Interviewers Expect
+- 
+
+### Common Follow-ups
+- 

--- a/classical/README.md
+++ b/classical/README.md
@@ -1,0 +1,21 @@
+# Classical Systems
+
+Traditional distributed systems design.
+
+**Core concerns:** Scalability, Availability, Consistency (CAP), Latency, Throughput
+
+## Cases
+
+| System | Key Challenge |
+|---|---|
+| [URL Shortener](./cases/url-shortener/) | Read-heavy, hashing, redirects at scale |
+| [Twitter Feed](./cases/twitter-feed/) | Fan-out, timeline generation, hot users |
+| [Uber](./cases/uber/) | Geo-spatial indexing, real-time matching, surge pricing |
+
+## Patterns
+
+| Pattern | Used In |
+|---|---|
+| [Rate Limiting](./patterns/rate-limiting/) | API gateways, abuse prevention |
+| [Caching](./patterns/caching/) | Feed, search, session |
+| [Consistent Hashing](./patterns/consistent-hashing/) | Distributed caches, sharding |

--- a/classical/cases/url-shortener/README.md
+++ b/classical/cases/url-shortener/README.md
@@ -1,0 +1,279 @@
+# URL Shortener
+
+Design a service like bit.ly that converts long URLs to short ones and redirects users.
+
+---
+
+## Requirements
+
+### Functional Requirements
+- Given a long URL, generate a unique short URL
+- Redirect short URL → original URL
+- Optional: custom aliases, link expiry, click analytics
+
+### Non-Functional Requirements
+- Latency: redirect < 10ms p99 (critical — on every click)
+- Availability: 99.99% (redirect failures are user-visible)
+- Consistency: eventual consistency acceptable — short URL resolves within seconds of creation
+- Security & Privacy: prevent enumeration attacks; no user PII stored in URL records by default
+- Scalability: 100M URLs created/day; 10:1 read/write ratio
+
+### Out of Scope
+- User accounts / auth
+- Real-time analytics dashboard (async analytics pipeline)
+- Link previews / safety scanning
+
+---
+
+## Back-of-Envelope Estimation
+
+### Traffic Estimation
+| Metric | Value |
+|---|---|
+| Writes (URL creation) | 100M/day → ~1,200/sec |
+| Reads (redirects) | 1B/day → ~12,000/sec |
+| Read/write ratio | 10:1 |
+
+### Storage Estimation
+| Metric | Value |
+|---|---|
+| Avg record size | ~500 bytes |
+| Records/day | 100M |
+| Storage/day | ~50 GB |
+| Storage (5yr) | ~90 TB |
+
+### Memory Estimation
+| Metric | Value |
+|---|---|
+| Hot URLs (20% drive 80% traffic) | ~20M records |
+| Cache size (500B × 20M) | ~10 GB |
+
+### Bandwidth Estimation
+| Metric | Value |
+|---|---|
+| Write throughput | ~600 KB/s |
+| Read throughput | ~6 MB/s |
+
+---
+
+## High-Level Design
+
+### Architecture Style
+**Stateless Microservices** — read and write paths separated; redirect service scales independently from creation service. Read path is extremely hot; cache layer critical.
+
+### Architecture Diagram
+```
+Client
+  ↓
+CDN (cache redirect responses)
+  ↓
+Load Balancer
+  ├── Write Service (POST /shorten)
+  │       ↓
+  │   ID Generator (Snowflake)
+  │       ↓
+  │   DB Write (Cassandra) + Cache Warm
+  │
+  └── Redirect Service (GET /{code})
+          ↓
+      Cache (Redis) ──hit──→ 302 Redirect
+          ↓ miss
+      DB Read (Cassandra)
+          ↓
+      Cache Write + 302 Redirect
+          ↓ async
+      Analytics Event (Kafka)
+```
+
+### Core Components
+| Component | Responsibility |
+|---|---|
+| Write Service | Validate URL, generate short code, persist, warm cache |
+| Redirect Service | Resolve short code → long URL via cache → DB; issue redirect |
+| ID Generator | Distributed unique ID generation (Snowflake) → Base62 encode |
+| Cache (Redis) | Short code → long URL; hot path, sub-millisecond lookup |
+| DB (Cassandra) | Persistent store; key-value access pattern; high read throughput |
+| CDN | Cache redirect responses for popular short URLs at edge |
+| Analytics Pipeline | Async click event processing (Kafka → consumer → data warehouse) |
+
+### Data Flow
+
+**URL Creation:**
+1. Client POST `/shorten` with long URL
+2. Write service validates URL (format, blocklist check)
+3. ID generator produces unique integer → Base62 encode → 7-char short code
+4. Write to Cassandra (short_code → record)
+5. Warm Redis cache
+6. Return short URL to client
+
+**Redirect:**
+1. Client GET `/{short_code}` → hits CDN first
+2. CDN miss → Redirect service → Redis lookup
+3. Redis hit → 302 response immediately
+4. Redis miss → Cassandra read → populate Redis → 302 response
+5. Async: publish click event to Kafka
+
+### Key Design Decisions
+- **302 over 301 redirect:** 301 is cached by browser permanently — no analytics, no way to update. 302 always hits server — enables click tracking, expiry enforcement, URL updates.
+- **Base62 encoding of Snowflake ID:** Avoids collision risk of MD5/hash. Snowflake gives globally unique monotonic ID; Base62 gives short, URL-safe string.
+- **Cassandra over SQL:** Access pattern is pure key-value (short_code lookup). Cassandra excels at high read throughput, horizontal scaling, no joins needed.
+- **CDN for top URLs:** Popular links (viral content) cause thundering herd on redirect service. CDN caches 302 responses at edge — eliminates server load for hot URLs.
+
+---
+
+## Low-Level Design
+
+### Data Models
+```
+urls (Cassandra):
+  short_code    VARCHAR   PK
+  long_url      TEXT
+  user_id       VARCHAR   (nullable)
+  created_at    TIMESTAMP
+  expires_at    TIMESTAMP (nullable)
+  custom_alias  BOOLEAN
+
+analytics (Cassandra — separate table):
+  short_code    VARCHAR   partition key
+  clicked_at    TIMESTAMP clustering key
+  user_agent    TEXT
+  country       TEXT
+  referrer      TEXT
+```
+
+### API Design
+```
+POST /shorten
+Request:  { "long_url": "https://...", "custom_alias": "my-link", "expires_in_days": 30 }
+Response: { "short_url": "https://sho.rt/aB3xYz7", "short_code": "aB3xYz7" }
+
+GET /{short_code}
+Response: HTTP 302 Location: <long_url>
+          HTTP 404 if not found or expired
+
+GET /analytics/{short_code}
+Response: { "total_clicks": 12345, "clicks_by_country": {...}, "clicks_by_day": {...} }
+
+DELETE /{short_code}
+Response: HTTP 204
+```
+
+### Component Deep-Dives
+
+#### ID Generator (Snowflake-based)
+```
+64-bit Snowflake ID:
+  [41 bits timestamp][10 bits machine_id][12 bits sequence]
+
+→ Base62 encode (a-z, A-Z, 0-9)
+→ 7-character short code (62^7 = 3.5 trillion unique codes)
+```
+
+Why not hash (MD5/SHA): collision risk at scale; requires collision detection retry loop. Snowflake is collision-free by construction.
+
+#### Cache Strategy (Redis)
+```
+Key:   short_code
+Value: { long_url, expires_at }
+TTL:   24 hours (refresh on access for active links)
+```
+
+On redirect:
+1. GET short_code from Redis
+2. Check expires_at in value (not just Redis TTL) — allows accurate expiry without relying on TTL precision
+3. Cache miss → Cassandra → SET in Redis with 24hr TTL
+
+#### Custom Alias
+- User provides alias → check Redis + Cassandra for collision → reserve if free
+- Rate limit: max 10 custom aliases per user per day (prevent squatting)
+
+#### Guardrails / Safety Layer
+- URL validation: must parse as valid HTTP/HTTPS URL
+- Blocklist check: scan long URL against known phishing/malware domains (Google Safe Browsing API)
+- Rate limiting: max 100 URL creations per IP per hour
+- Short code enumeration prevention: 7-char Base62 space is 3.5T — brute force infeasible; no sequential exposure (Snowflake IDs are not exposed directly)
+
+### Algorithms & Strategies
+- **ID generation:** Snowflake (distributed, monotonic, no coordination needed). Each write service node has unique `machine_id` (assigned at startup from ZooKeeper or env config).
+- **Caching strategy:** Cache-aside pattern. Redis TTL: 24hr with sliding expiry on access. Eviction: LRU (hot URLs stay, cold URLs evicted).
+- **Expiry enforcement:** expires_at stored in Cassandra and Redis value. Redirect service checks at read time — expired link returns 410 Gone. Background job cleans up expired rows weekly.
+- **Analytics:** Fire-and-forget Kafka publish on each redirect. Consumer aggregates into ClickHouse (OLAP). No sync dependency on analytics for redirect latency.
+
+### Security Design
+- AuthN/AuthZ: API key for URL creation; public for redirects (no auth needed)
+- Short code space: 62^7 = 3.5T codes — enumeration attack impractical
+- Blocklist: Google Safe Browsing API integration on creation; periodic re-scan of existing URLs
+- Encryption at rest: Cassandra encrypted; Redis encrypted
+- Encryption in transit: TLS 1.3 on all endpoints
+- PII: user_id stored only if authenticated; click analytics anonymized (IP not stored, country derived then discarded)
+- Rate limiting: per-IP on creation endpoint (prevent abuse/spam)
+
+---
+
+## Observability
+
+### Metrics
+| Metric | Type | Alert threshold |
+|---|---|---|
+| Redirect latency (p99) | Histogram | > 10ms |
+| Cache hit rate | Gauge | < 90% |
+| URL creation rate | Counter | — |
+| 404 rate | Counter | > 1% (possible enumeration attack) |
+| DB read latency (p99) | Histogram | > 50ms |
+
+### Logging
+- Per redirect: short_code, cache_hit, latency, status_code, country (derived)
+- Per creation: short_code, url_hash (not raw URL), user_id_hash, is_custom_alias
+- Do NOT log: raw long_url (may contain auth tokens), full user IPs
+
+### Tracing
+- Trace spans: CDN → redirect_service → redis_lookup → cassandra_read
+- Sample: 1% normal (extremely high volume); 100% on 404s and errors
+
+### Alerting
+| Alert | Threshold | Action |
+|---|---|---|
+| Redirect latency spike | p99 > 10ms | Check Redis hit rate, scale redirect service |
+| Cache hit rate drop | < 85% | Check Redis memory, eviction rate |
+| 404 rate spike | > 2% | Possible enumeration attack — rate limit by IP |
+| DB latency spike | p99 > 100ms | Check Cassandra node health |
+
+---
+
+## Tradeoffs
+
+| Decision | Chose | Sacrificed |
+|---|---|---|
+| 302 redirect | Analytics accuracy, expiry control | Browser-side caching (every click hits server) |
+| Base62 + Snowflake ID | Zero collision, no retry needed | Need distributed ID generator infrastructure |
+| Cassandra over MySQL | Horizontal scale, high read throughput | No ACID transactions (not needed for this use case) |
+| CDN for hot URLs | Edge-cached redirects (0ms server load) | 302 cached at CDN — analytics undercounted for viral links |
+| Async analytics (Kafka) | Zero impact on redirect latency | Analytics lag (minutes), not real-time |
+
+---
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| Redis down | OOM or node failure | Fail open to Cassandra; pre-warm Redis on recovery |
+| Cassandra node down | Hardware failure | Cassandra replication (RF=3); redirect degrades gracefully with remaining nodes |
+| ID generator down | Snowflake node crash | Multiple ID generator instances; fallback to secondary |
+| Hot URL cache miss storm | Viral link, cache cold | CDN absorbs; probabilistic early expiry (cache refresh before TTL) |
+| Expired link redirect | expires_at not checked | Check expires_at in value, not just Redis TTL; return 410 Gone |
+
+---
+
+## Interview Tips
+
+### What Interviewers Expect
+- ID generation strategy — must explain Snowflake vs hash and why Snowflake wins
+- 301 vs 302 tradeoff — always ask this; 302 is correct answer for analytics
+- Cache hierarchy: CDN → Redis → Cassandra (three layers)
+- Cassandra choice: justify key-value access pattern
+
+### Common Follow-ups
+- How to handle expiry at scale? TTL in Redis + check expires_at at read time + async cleanup job
+- Hot URL problem (thundering herd)? CDN layer + probabilistic early cache refresh
+- Custom aliases at scale? Separate lookup table; rate-limit to prevent squatting
+- Analytics at scale? Kafka → ClickHouse OLAP pipeline; HyperLogLog for unique visitor counts

--- a/genai-systems/README.md
+++ b/genai-systems/README.md
@@ -1,0 +1,21 @@
+# GenAI Systems
+
+LLM-native architecture design.
+
+**Core concerns:** Context window limits, Cost per token, Hallucination, Latency, Evaluation
+
+## Cases
+
+| System | Key Challenge |
+|---|---|
+| [RAG Pipeline](./cases/rag-pipeline/) | Retrieval quality, chunking strategy, context stuffing |
+| [AI Agent](./cases/ai-agent/) | Tool use, memory, multi-step reasoning, failure recovery |
+| [LLM Gateway](./cases/llm-gateway/) | Multi-provider routing, rate limits, cost tracking, caching |
+
+## Patterns
+
+| Pattern | Used In |
+|---|---|
+| [Prompt Caching](./patterns/prompt-caching/) | Cost reduction for repeated system prompts |
+| [Vector Search](./patterns/vector-search/) | Semantic retrieval in RAG, memory systems |
+| [Evaluation](./patterns/evaluation/) | LLM-as-judge, regression testing, golden sets |

--- a/genai-systems/cases/ai-agent/README.md
+++ b/genai-systems/cases/ai-agent/README.md
@@ -1,0 +1,377 @@
+# AI Agent
+
+Design an LLM-powered agent that autonomously completes multi-step tasks using tools (web search, code execution, APIs).
+
+---
+
+## Requirements
+
+### Functional Requirements
+- Accept high-level goal from user in natural language
+- Break goal into steps; select and invoke tools autonomously
+- Handle tool errors and retry with corrected inputs
+- Maintain memory across steps within a single task
+- Maintain long-term memory across sessions (user preferences, past tasks)
+- Return final answer with reasoning trace
+- Support human-in-the-loop confirmation for irreversible actions
+
+### Non-Functional Requirements
+- Latency: best-effort for long tasks (async acceptable); interactive steps < 3s
+- Availability: 99.9% on task submission; individual tool failures handled gracefully
+- Consistency: task traces are durable and reproducible for debugging
+- Security & Privacy: no irreversible action without confirmation gate; PII not stored in plaintext memory
+- Scalability: 10,000 concurrent tasks; each task can span 2–50 LLM calls
+
+### Out of Scope
+- Training or fine-tuning LLM
+- Building individual tools (search API, code sandbox — integrated, not built)
+- UI / frontend
+
+---
+
+## Back-of-Envelope Estimation
+
+### Traffic Estimation
+| Metric | Value |
+|---|---|
+| Tasks/day | 100,000 |
+| Avg steps/task | 10 |
+| LLM calls/day | 1M |
+| Concurrent tasks (peak) | 10,000 |
+
+### Storage Estimation
+| Metric | Value |
+|---|---|
+| Trace per task | ~20 KB |
+| Traces/day | ~2 GB |
+| Long-term memory per user | ~50 KB |
+| Total memory store (1M users) | ~50 GB |
+
+### Memory Estimation
+| Metric | Value |
+|---|---|
+| Active task context (Redis) | ~10 GB |
+| Vector memory index (long-term) | ~20 GB |
+
+### Bandwidth Estimation
+| Metric | Value |
+|---|---|
+| LLM input tokens/day | ~500M |
+| LLM output tokens/day | ~200M |
+
+### Cost Estimation
+| Metric | Value |
+|---|---|
+| LLM calls/day | 1M |
+| Avg tokens/call | 3,000 input + 500 output |
+| Estimated cost/day | ~$3,000–$8,000 |
+| Prompt caching savings (system prompt) | ~30% of input token cost |
+
+---
+
+## High-Level Design
+
+### Architecture Style
+**Event-driven Orchestration + Stateless Worker Nodes** — task orchestrator manages state and step sequencing; agent worker nodes are stateless and horizontally scalable; all task state lives in external stores.
+
+### Architecture Diagram
+```
+User
+  ↓
+Task API (submit / status / cancel)
+  ↓
+Task Queue (Kafka)
+  ↓
+Agent Orchestrator
+  ├── State Manager (Redis — current step, context)
+  ├── LLM Planner (reason + select tool)
+  │         ↓
+  ├── Tool Router
+  │    ├── Web Search
+  │    ├── Code Executor (sandboxed)
+  │    ├── API Caller
+  │    └── Memory Tool (read/write)
+  │         ↓
+  ├── Safety Filter (pre + post tool call)
+  ├── Memory Manager
+  │    ├── Short-term (Redis, task-scoped)
+  │    └── Long-term (Vector DB, cross-session)
+  └── Trace Logger (S3 / DB — immutable audit)
+        ↓
+Task Result → User (webhook / polling)
+```
+
+### Core Components
+| Component | Responsibility |
+|---|---|
+| Task API | Accept tasks, expose status + cancellation endpoints |
+| Agent Orchestrator | Drive ReAct loop; manage step state; decide continue/stop |
+| LLM Planner | Generate Thought → Action → Observation at each step |
+| Tool Router | Parse LLM tool call → dispatch to correct tool executor |
+| Safety Filter | Validate tool inputs pre-execution; filter outputs post-execution |
+| Memory Manager | Read/write short-term (task) and long-term (user) memory |
+| Trace Logger | Persist full task trace (steps, tool calls, results) for replay/debug |
+
+### Data Flow
+
+**Task Execution (ReAct loop):**
+1. User submits task → Task API creates task record → publishes to Kafka
+2. Agent worker picks up task → loads task context from Redis
+3. LLM Planner receives (goal + history + available tools) → outputs Thought + Action
+4. Tool Router parses Action → Safety Filter validates → dispatches tool
+5. Tool executes → result returned as Observation
+6. Orchestrator appends Observation to context → loop back to step 3
+7. LLM outputs `Final Answer` → task marked complete → user notified
+8. Trace written to S3; long-term memory updated asynchronously
+
+**Memory Read (step 3 enrichment):**
+- Before LLM call: query long-term memory with current goal → inject relevant past context
+- Short-term: last N steps from Redis context
+
+### Key Design Decisions
+- **ReAct (Reason + Act) pattern:** LLM alternates between Thought (reasoning) and Action (tool call). Observable, debuggable, adaptive to intermediate errors. Alternative: Plan-then-Execute (upfront plan, parallel steps) for deterministic tasks.
+- **Async task execution:** Agent tasks are long-running (seconds to minutes). Submit-and-poll pattern avoids holding HTTP connections.
+- **External memory:** In-context window alone insufficient for long tasks (50+ steps) or cross-session memory. Redis for short-term (fast, TTL-based); Vector DB for long-term (semantic retrieval).
+- **Safety gate:** Read-only tools auto-approved; write/delete/send require confirmation gate or policy check. Non-negotiable for production agents.
+- **Model Selection:** Claude Sonnet / GPT-4o for planning (strong reasoning, tool use). Haiku / GPT-4o-mini for short intermediate steps to reduce cost. Routing based on step complexity.
+
+---
+
+## Low-Level Design
+
+### Data Models
+```
+tasks (PostgreSQL):
+  task_id       UUID      PK
+  user_id       UUID
+  goal          TEXT
+  status        ENUM (queued, running, paused, complete, failed)
+  result        TEXT      (nullable)
+  created_at    TIMESTAMP
+  updated_at    TIMESTAMP
+  step_count    INTEGER
+  max_steps     INTEGER   (default 50)
+
+task_steps (PostgreSQL):
+  step_id       UUID      PK
+  task_id       UUID      FK
+  step_index    INTEGER
+  thought       TEXT
+  action        JSONB     { tool, args }
+  observation   TEXT
+  timestamp     TIMESTAMP
+
+task_context (Redis):
+  key: "ctx:{task_id}"
+  value: {
+    goal, step_history (last 20), current_step,
+    tools_available, user_id
+  }
+  TTL: 2 hours
+
+long_term_memory (Vector DB):
+  id        = memory_id
+  vector    = float32[1536]   (embed of memory content)
+  payload   = { user_id, content, memory_type, created_at, task_id }
+
+user_memory_index (PostgreSQL):
+  memory_id     UUID      PK
+  user_id       UUID
+  content       TEXT
+  memory_type   ENUM (preference, fact, past_task)
+  created_at    TIMESTAMP
+```
+
+### API Design
+```
+POST /tasks
+Request:  { "goal": "Research competitors and summarize pricing", "max_steps": 30 }
+Response: { "task_id": "...", "status": "queued" }
+
+GET /tasks/{task_id}
+Response: { "status": "running", "step_count": 7, "latest_thought": "..." }
+
+GET /tasks/{task_id}/trace
+Response: { "steps": [{ "thought": "...", "action": {...}, "observation": "..." }] }
+
+POST /tasks/{task_id}/confirm
+Request:  { "action_id": "...", "approved": true }
+Response: { "status": "resumed" }
+
+DELETE /tasks/{task_id}
+Response: { "status": "cancelled" }
+```
+
+### Component Deep-Dives
+
+#### ReAct Loop (Orchestrator)
+```
+while step_count < max_steps:
+    context = build_context(goal, history, memory, tools)
+    llm_response = llm.complete(context)
+
+    if llm_response.is_final_answer:
+        complete_task(llm_response.answer)
+        break
+
+    action = parse_tool_call(llm_response)
+    safety_result = safety_filter.check(action)
+
+    if safety_result == REQUIRES_CONFIRMATION:
+        pause_task(); notify_user(); wait_for_confirm()
+
+    observation = tool_router.execute(action)
+    append_step(thought, action, observation)
+    step_count += 1
+else:
+    fail_task("max_steps exceeded")
+```
+
+#### Memory Manager — Memory Types
+| Type | Scope | Storage | TTL | Retrieval |
+|---|---|---|---|---|
+| In-context | Current request | LLM context window | — | Direct injection |
+| Short-term | Current task | Redis | 2hr | Key lookup |
+| Long-term | Cross-session | Vector DB + PostgreSQL | Permanent | Semantic search |
+| Episodic | Specific past events | Vector DB | Permanent | Semantic search |
+
+Long-term memory write: after task complete → embed key takeaways → store in Vector DB with user_id filter.
+
+Long-term memory read: before each LLM call → embed current goal → top-3 relevant memories → inject into context.
+
+#### Tool Design Contract
+```json
+{
+  "name": "web_search",
+  "description": "Search the web for current information. Use for recent events, facts, prices.",
+  "parameters": {
+    "query": { "type": "string", "description": "search query" },
+    "max_results": { "type": "integer", "default": 5 }
+  },
+  "returns": "list of { title, url, snippet }",
+  "safety_class": "read_only"
+}
+```
+
+`safety_class` values:
+- `read_only` → auto-approve
+- `write` → policy check (rate limit, scope validation)
+- `destructive` → require explicit user confirmation
+
+#### Guardrails / Safety Layer
+
+**Pre-execution (input validation):**
+- Schema validation: tool args match declared parameter types
+- Scope check: agent cannot call tools outside task-granted permissions
+- Prompt injection detection: scan tool outputs before feeding back to LLM (`ignore previous instructions`, etc.)
+- Destructive action gate: DELETE / SEND / POST to external services require confirmation
+
+**Post-execution (output filtering):**
+- Strip PII from tool observations before storing in memory
+- Truncate large outputs before context injection (max 2000 tokens per observation)
+- Flag anomalous outputs (e.g., tool returned HTML error page instead of JSON)
+
+#### Loop Detector
+```
+if last 3 (action, args) tuples are identical → break loop
+if step_count > 0.8 * max_steps → inject "you are running out of steps, aim to finalize" hint
+```
+
+### Algorithms & Strategies
+- **Context window management:** Keep last 20 steps in context. Summarize older steps via LLM ("summarize these steps in 200 tokens") when approaching limit.
+- **Tool selection:** LLM selects from tool schema list injected in system prompt. Descriptions must be precise — LLM matches intent to description.
+- **Prompt design:** System prompt includes: agent role, tool schemas, memory snippets, output format (JSON with `thought`, `action` or `final_answer`). Prompt cached at provider level (Anthropic/OpenAI prompt caching) to reduce cost.
+- **Retry strategy:** Tool failures → retry up to 3× with exponential backoff. After 3 failures → LLM observes failure and selects alternative approach.
+- **Plan-and-Execute variant:** For complex tasks, first call LLM to generate full plan (list of steps) → execute steps sequentially or in parallel → reduces total LLM calls for deterministic flows.
+
+### Security Design
+- AuthN/AuthZ: task_id + user_id scoped; agent cannot access other users' tasks or memory
+- Tool permissions: per-task permission manifest; agent cannot escalate
+- Code execution: sandboxed (gVisor / Firecracker VM); no network access from sandbox; timeout 30s; resource limits (CPU, mem, disk)
+- Secrets: no secrets in agent context; tools call APIs server-side, credentials not exposed to LLM
+- Audit: all tool calls logged immutably (action, args, result, user_id, timestamp) to S3 with Object Lock
+- PII: strip from memory before storage; task goal hashed in logs
+
+---
+
+## Observability
+
+### Metrics
+| Metric | Type | Alert threshold |
+|---|---|---|
+| Task completion rate | Gauge | < 80% |
+| Avg steps per task | Histogram | > 40 (approaching limit) |
+| Tool error rate (per tool) | Counter | > 5% |
+| Safety gate trigger rate | Counter | > 1% (unexpected spike) |
+| LLM call latency (p95) | Histogram | > 5s |
+| Memory retrieval latency | Histogram | > 100ms |
+
+### Logging
+- Per step: task_id, step_index, tool_name, tool_args_hash, observation_length, latency, safety_result
+- Per task: task_id, user_id, goal_hash, step_count, outcome (complete/failed/cancelled), total_cost
+- Do NOT log: raw goal text (PII risk), raw tool observations, memory content
+
+### Tracing
+- Trace spans: task_submit → orchestrator_pickup → llm_plan → tool_dispatch → tool_execute → memory_update
+- Cross-step trace: single trace_id per task, child spans per step
+- Sample: 20% normal; 100% on failures or tasks > 30 steps
+
+### Alerting
+| Alert | Threshold | Action |
+|---|---|---|
+| Task failure rate spike | > 20% for 5min | Page on-call |
+| Code sandbox timeout | > 5% requests | Check sandbox capacity |
+| LLM provider errors | > 2% for 2min | Failover to backup model |
+| Infinite loop detection | > 50 tasks in loop state | Alert + auto-cancel |
+
+---
+
+## Tradeoffs
+
+| Decision | Chose | Sacrificed |
+|---|---|---|
+| ReAct over Plan-Execute | Adaptive to intermediate errors | More LLM calls = higher cost |
+| External memory (Redis + Vector DB) | Long task + cross-session support | Retrieval latency + sync complexity |
+| Async task execution | UX responsiveness | Harder error surfacing (polling vs push) |
+| Strict tool schemas | Reduces hallucinated tool calls | Less flexible; schema updates need deploy |
+| Safety gate for destructive actions | Prevents irreversible mistakes | Adds friction for power users |
+| Context window summarization | Handles long tasks | Summarization loses detail; LLM cost |
+
+---
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| Infinite loop | LLM stuck in same reasoning pattern | Loop detector; max_steps hard cap; inject "finalize now" hint |
+| Tool hallucination | LLM invents args or fabricates results | Strict JSON schema validation; observation consistency check |
+| Context overflow | Long task exceeds context window | Sliding window (last 20 steps) + episodic summary |
+| Irreversible action | Agent acts without confirmation | Safety gate; `destructive` tool class blocks without user ack |
+| Cascading errors | One bad tool result poisons next steps | Checkpoint state; allow human-in-loop recovery |
+| Memory poisoning | Bad data stored in long-term memory | TTL + confidence scoring; user can clear memory |
+| Code sandbox escape | Malicious code in tool input | gVisor isolation; no network; resource limits; auto-kill on timeout |
+
+---
+
+## Feedback Loop & Improvements
+- Task completion rated by user (1-5 or success/failure)
+- Failed tasks reviewed: classify failure (tool error, reasoning error, safety block, timeout)
+- Low-rated task traces used to: improve tool descriptions, add examples to system prompt, adjust safety thresholds
+- Memory quality: user can flag bad memories for removal
+- Eval cadence: benchmark on fixed task suite per model version change (task completion rate, avg steps)
+
+---
+
+## Interview Tips
+
+### What Interviewers Expect
+- ReAct loop as baseline — must explain Thought / Action / Observation clearly
+- Memory design is the crux — distinguish in-context vs short-term vs long-term
+- Safety: how to prevent irreversible actions — confirmation gate + safety_class per tool
+- Async execution: why agent tasks can't be synchronous HTTP calls
+
+### Common Follow-ups
+- Multi-agent: supervisor routes subtasks to specialized sub-agents (researcher, coder, critic) → results synthesized
+- Evaluation: task completion rate + step efficiency (fewer steps = better planning) + human eval
+- How to handle streaming? SSE for step-by-step thought visibility
+- Cost control: route short steps to cheaper model; cache system prompt; limit max_steps

--- a/genai-systems/cases/llm-gateway/README.md
+++ b/genai-systems/cases/llm-gateway/README.md
@@ -1,0 +1,325 @@
+# LLM Gateway
+
+Design a centralized gateway that routes LLM requests across multiple providers, handles rate limits, tracks cost, and caches responses.
+
+---
+
+## Requirements
+
+### Functional Requirements
+- Unified API — clients use one interface regardless of backend LLM provider
+- Route requests to multiple providers (OpenAI, Anthropic, Gemini, Mistral, local models)
+- Semantic response caching for repeated/similar queries
+- Cost tracking per user / team / project
+- Rate limiting per tenant at both request and token level
+- Automatic failover when a provider fails or is slow
+
+### Non-Functional Requirements
+- Latency: gateway overhead < 20ms p99 on cache miss path
+- Availability: 99.99% — higher than any single LLM provider
+- Consistency: cost ledger eventually consistent (< 1min lag acceptable)
+- Security & Privacy: PII scrubbing before logging; audit trail of all requests
+- Scalability: 10M requests/day, 5+ providers
+
+### Out of Scope
+- Fine-tuning or hosting LLM models
+- Prompt template management (separate system)
+- Per-request content moderation (handled upstream)
+
+---
+
+## Back-of-Envelope Estimation
+
+### Traffic Estimation
+| Metric | Value |
+|---|---|
+| Requests/day | 10M |
+| Requests/sec (peak) | ~500 |
+| Avg tokens/request | 2,000 input + 500 output |
+
+### Storage Estimation
+| Metric | Value |
+|---|---|
+| Audit log/request | ~2 KB |
+| Audit log/day | ~20 GB |
+| Cost ledger/day | ~1 GB |
+
+### Memory Estimation
+| Metric | Value |
+|---|---|
+| Semantic cache (vector index) | ~50 GB |
+| Rate limit counters (Redis) | ~1 GB |
+
+### Bandwidth Estimation
+| Metric | Value |
+|---|---|
+| Token throughput (input) | ~1B tokens/day |
+| Token throughput (output) | ~250M tokens/day |
+
+### Cost Estimation
+| Metric | Value |
+|---|---|
+| Tokens/day | ~1.25B |
+| Expected cost/day (blended) | ~$5,000–$20,000 |
+| Cache hit target (30%) saves | ~$1,500–$6,000/day |
+
+---
+
+## High-Level Design
+
+### Architecture Style
+**Stateless Microservice + External State Stores** — gateway nodes are stateless for easy horizontal scaling; all state (cache, rate limits, cost) lives in Redis and Vector DB.
+
+### Architecture Diagram
+```
+Client SDK
+    ↓
+Load Balancer
+    ↓
+LLM Gateway (stateless, horizontally scaled)
+    ├── 1. Auth & Tenant Resolution
+    ├── 2. Rate Limiter (Redis token bucket)
+    ├── 3. Semantic Cache (check)  ──── hit → return cached response
+    │         ↓ miss
+    ├── 4. Router (provider + model selection)
+    ├── 5. Provider Adapter (normalize request)
+    │         ↓
+    ├── LLM Providers (OpenAI / Anthropic / Gemini / ...)
+    │         ↓
+    ├── 6. Semantic Cache (write, async)
+    ├── 7. Cost Tracker (async → Kafka → ClickHouse)
+    └── 8. Audit Logger (async → S3)
+```
+
+### Core Components
+| Component | Responsibility |
+|---|---|
+| Auth & Tenant Resolution | Validate API key; resolve tenant_id, plan, quotas |
+| Rate Limiter | Token bucket per tenant per model; request + token level |
+| Semantic Cache | Embed query, find similar past responses, return on hit |
+| Router | Select provider + model based on strategy (cost, latency, capability) |
+| Provider Adapter | Normalize request/response across provider APIs |
+| Cost Tracker | Async cost calculation and ledger update |
+| Audit Logger | Immutable log of all requests for compliance |
+
+### Data Flow
+
+**Cache miss (full path):**
+1. Client sends request → Auth resolves tenant + quota
+2. Rate limiter checks token bucket (Redis) — reject if exceeded
+3. Query embedded → semantic cache search — miss
+4. Router selects provider (e.g., cheapest that meets capability)
+5. Provider adapter normalizes request → calls LLM provider
+6. Response returned to client
+7. Async: write to semantic cache, publish cost event to Kafka, write audit log to S3
+
+**Cache hit:**
+1-3 same as above — cache hit at step 3
+4. Return cached response immediately (no provider call)
+5. Async: log cache hit event for analytics
+
+### Key Design Decisions
+- **Semantic cache over exact match:** LLM queries are natural language — exact match hit rate near 0%. Embedding similarity (cosine > 0.95 threshold) achieves 30%+ hit rate.
+- **Async cost tracking:** Writing cost synchronously adds DB latency on critical path. Kafka + ClickHouse pipeline gives < 1min eventual consistency — acceptable for budget enforcement.
+- **Token-level rate limiting:** Request-level alone is insufficient — one request with 100K tokens is very different from one with 500. Enforce both dimensions.
+- **Stateless gateway nodes:** All state in Redis/Vector DB — nodes can scale horizontally and fail independently.
+- **Model Selection:** Provider adapters abstract provider differences. Router selects based on configured strategy (cost, latency, capability requirements).
+
+---
+
+## Low-Level Design
+
+### Data Models
+```
+api_keys table (PostgreSQL):
+  key_hash      VARCHAR   PK
+  tenant_id     UUID
+  plan          ENUM (free, pro, enterprise)
+  created_at    TIMESTAMP
+  revoked_at    TIMESTAMP (nullable)
+
+tenant_quotas table (PostgreSQL):
+  tenant_id           UUID    PK
+  rpm_limit           INTEGER  (requests per minute)
+  tpm_limit           INTEGER  (tokens per minute)
+  daily_token_budget  BIGINT
+
+cost_ledger (ClickHouse):
+  request_id    UUID
+  tenant_id     UUID
+  model         VARCHAR
+  provider      VARCHAR
+  input_tokens  INTEGER
+  output_tokens INTEGER
+  cost_usd      DECIMAL
+  timestamp     DATETIME
+
+semantic_cache (Vector DB):
+  id            = cache_id
+  vector        = float32[1536]
+  metadata      = { response, model, system_prompt_hash, tenant_id, created_at }
+
+rate_limit_counters (Redis):
+  key: "rl:{tenant_id}:{model}:rpm"  → token bucket state
+  key: "rl:{tenant_id}:tpm"          → tokens-per-minute counter
+  key: "budget:{tenant_id}:daily"    → daily token spend counter
+```
+
+### API Design
+```
+POST /v1/chat/completions          ← OpenAI-compatible interface
+Request:  {
+  "model": "claude-sonnet-4-6",   ← gateway model alias
+  "messages": [...],
+  "temperature": 0.7,
+  "x-gateway-strategy": "cost"    ← optional routing hint
+}
+Response: { "id": "...", "choices": [...], "usage": {...} }
+
+GET /v1/usage
+Response: { "tokens_today": 1234567, "cost_today_usd": 12.34, "budget_remaining_usd": 87.66 }
+
+GET /v1/providers/health
+Response: { "openai": "healthy", "anthropic": "degraded", "gemini": "healthy" }
+```
+
+### Component Deep-Dives
+
+#### Semantic Cache
+```
+Incoming query
+    ↓
+Embed (text-embedding-3-small — cheap, fast)
+    ↓
+Vector search (cosine similarity)
+    ↓
+sim > 0.95 AND same (system_prompt_hash, model, tenant_id)?
+    ├── YES → return cached response
+    └── NO  → call provider → store (vector, response) async
+```
+
+Do NOT cache:
+- `temperature > 0` (non-deterministic)
+- Streaming requests (cache only on complete response)
+- Tool calls with side effects
+
+#### Provider Adapter
+```python
+class ProviderAdapter:
+    def complete(self, messages, model, tools, max_tokens) -> Response
+    def stream(self, ...) -> AsyncIterator[Chunk]
+    def embed(self, texts) -> List[Vector]
+    def count_tokens(self, messages) -> int
+```
+
+Each provider (OpenAI, Anthropic, Gemini) implements this interface. Gateway never calls provider SDK directly — always through adapter.
+
+#### Router — Routing Strategies
+| Strategy | Logic |
+|---|---|
+| Cost-optimized | Cheapest model meeting capability requirement |
+| Latency-optimized | Provider with lowest live p50 (tracked in Redis, refreshed every 30s) |
+| Failover | Primary → secondary on 5xx or timeout (circuit breaker per provider) |
+| Capability-based | Route vision/tool-use/long-context to capable provider |
+| A/B | Split traffic % for model comparison experiments |
+
+#### Guardrails / Safety Layer
+- PII scrubbing: scan request messages for emails, phone, SSN → redact before logging and caching
+- Prompt injection: detect `ignore previous instructions` patterns → flag, optionally block
+- Output filtering: optional profanity / harmful content filter (configurable per tenant)
+
+### Algorithms & Strategies
+- **Rate limiting:** Token bucket per (tenant, model) in Redis. Bucket refills at `tpm_limit / 60` tokens/sec. Reject with 429 when empty.
+- **Token pre-estimation:** Use tiktoken (OpenAI) or model-specific tokenizer to estimate input tokens before call — needed for token-level rate check. Actual count reconciled after response.
+- **Circuit breaker per provider:** Open after 5 consecutive 5xx in 10s window → route to backup → half-open after 30s.
+- **Caching strategy:** Semantic cache with cosine threshold 0.95. Cache key includes `system_prompt_hash` to prevent cross-context hits. TTL: 1 hour default, configurable.
+- **Cost calculation:** `cost = (input_tokens × input_price) + (output_tokens × output_price)`. Price table stored in config (Redis), not DB — update without deploy.
+
+### Security Design
+- AuthN: HMAC-SHA256 API key validation (compare key_hash, never store raw key)
+- AuthZ: tenant_id from resolved key — client cannot spoof
+- Encryption at rest: ClickHouse and audit S3 bucket encrypted
+- Encryption in transit: TLS 1.3 to clients and providers
+- Secrets management: provider API keys in AWS Secrets Manager, rotated monthly
+- PII handling: redact before audit log; raw prompts never stored long-term
+- Audit log: immutable (S3 Object Lock) — compliance requirement
+
+---
+
+## Observability
+
+### Metrics
+| Metric | Type | Alert threshold |
+|---|---|---|
+| Gateway latency (p99) | Histogram | > 20ms overhead |
+| Cache hit rate | Gauge | < 25% |
+| Provider error rate (per provider) | Counter | > 1% |
+| Rate limit rejection rate | Counter | > 5% |
+| Daily cost vs budget | Gauge | > 90% budget |
+
+### Logging
+- Per request: request_id, tenant_id, model, provider, latency, tokens_in, tokens_out, cost, cache_hit, status
+- Do NOT log: raw message content (PII risk); log content_hash instead for dedup
+
+### Tracing
+- Trace: Client → Gateway → Cache → Provider
+- Annotate: cache lookup latency, provider call latency, token estimation time
+- Sample: 5% normal, 100% on errors or latency > 500ms
+
+### Alerting
+| Alert | Threshold | Action |
+|---|---|---|
+| Provider degraded | Error rate > 1% for 2min | Failover, notify team |
+| Budget near limit | Tenant at 90% daily budget | Notify tenant, throttle |
+| Cache hit rate drop | < 20% for 10min | Investigate embedding quality or threshold |
+| Gateway latency spike | p99 > 50ms overhead | Scale gateway nodes |
+
+---
+
+## Tradeoffs
+
+| Decision | Chose | Sacrificed |
+|---|---|---|
+| Semantic cache (vector sim) | 30%+ hit rate | Occasional wrong cache hit (tune threshold) |
+| Async cost tracking | Zero latency on critical path | Eventual consistency — budget enforcement lags < 1min |
+| Token-level rate limiting | Prevents prompt stuffing abuse | Need token pre-estimation (slight overhead) |
+| Stateless gateway | Easy horizontal scale | Requires Redis + Vector DB for all state |
+| OpenAI-compatible API | Easy client migration | Lowest-common-denominator feature set |
+| Circuit breaker per provider | Fast failover | Flapping risk on unstable providers (tune thresholds) |
+
+---
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| All providers down | Simultaneous outage | Local model fallback (Ollama/vLLM); degrade gracefully |
+| Cache poisoning | Bad response cached | TTL expiry; user feedback triggers cache invalidation |
+| Budget overrun | Async lag in cost tracker | Soft limit (warn at 90%) + hard limit via Redis counter (sync) |
+| Rate limit bypass | Token pre-estimation wrong | Reconcile post-response; deduct difference from next bucket |
+| Provider API change | Breaking schema change | Provider adapter absorbs — update adapter, not gateway core |
+| Redis down | Rate limit state lost | Fail open (allow requests) with conservative global limit |
+
+---
+
+## Feedback Loop & Improvements
+- Track cache hit/miss + user satisfaction (if gateway has access to downstream rating)
+- Tune similarity threshold per tenant based on observed hit quality
+- A/B routing experiments: compare model outputs on same query → quality metrics → update default routing
+- Cost anomaly detection: alert on 3x spike vs 7-day rolling average per tenant
+
+---
+
+## Interview Tips
+
+### What Interviewers Expect
+- Semantic cache is the key differentiator — explain why exact match is useless for LLMs
+- Cost tracking pipeline: why async (Kafka), why ClickHouse (OLAP for cost queries)
+- Rate limiting: both request-level AND token-level — most candidates miss token-level
+- Failover: circuit breaker pattern per provider
+
+### Common Follow-ups
+- How to handle streaming responses? SSE passthrough — cache only on full response completion
+- PII in prompts → scrub before logging; never cache raw user content
+- How to support multimodal (image) requests? Provider adapter handles; image tokens counted separately
+- How to compare model quality? A/B routing with same query → LLM-as-judge scoring

--- a/genai-systems/cases/rag-pipeline/README.md
+++ b/genai-systems/cases/rag-pipeline/README.md
@@ -1,0 +1,331 @@
+# RAG Pipeline
+
+Design a Retrieval-Augmented Generation system that answers natural language questions grounded in a private knowledge base.
+
+---
+
+## Requirements
+
+### Functional Requirements
+- Ingest documents (PDF, HTML, Markdown, DOCX, etc.)
+- Answer natural language queries using ingested content
+- Return source citations alongside answers
+- Support incremental document updates (add, update, delete)
+- Filter results by metadata (date, department, document type)
+
+### Non-Functional Requirements
+- Latency: query response < 2s p95 end-to-end
+- Availability: 99.9% on query path; ingestion can tolerate delays
+- Consistency: new documents searchable within 5 minutes of upload
+- Security & Privacy: access control per document (tenant/role-based); PII not logged raw
+- Scalability: 10M+ document chunks; 1,000 QPS
+
+### Out of Scope
+- User authentication (handled upstream)
+- Document access permissions UI
+- Fine-tuning LLM on ingested content
+- Real-time streaming ingestion (batch ingestion sufficient)
+
+---
+
+## Back-of-Envelope Estimation
+
+### Traffic Estimation
+| Metric | Value |
+|---|---|
+| DAU | 50,000 |
+| Queries/day | 500,000 |
+| Queries/sec (peak) | ~1,000 |
+| Ingestion events/day | 10,000 docs |
+
+### Storage Estimation
+| Metric | Value |
+|---|---|
+| Avg doc size | 50 KB |
+| Chunks per doc (512 tokens, 50% overlap) | ~50 chunks |
+| Total chunks (1M docs) | ~50M chunks |
+| Embedding size (1536-dim float32) | 6 KB/chunk |
+| Vector index total | ~300 GB |
+| Raw doc storage (5yr) | ~5 TB |
+
+### Memory Estimation
+| Metric | Value |
+|---|---|
+| Hot vector index (in-memory HNSW) | ~50 GB |
+| Query embedding cache (Redis) | ~5 GB |
+
+### Bandwidth Estimation
+| Metric | Value |
+|---|---|
+| Ingestion throughput | ~500 KB/s |
+| Query response (avg 1KB) | ~1 MB/s |
+
+### Cost Estimation
+| Metric | Value |
+|---|---|
+| Embeddings at ingest (50M chunks) | ~$10,000 one-time |
+| Query embeddings/day (1,000 QPS) | ~500M tokens/day |
+| LLM generation/day | ~500M tokens/day |
+| Total cost/day (est.) | ~$2,000–$5,000 |
+
+---
+
+## High-Level Design
+
+### Architecture Style
+**Event-driven (ingestion) + Synchronous Microservices (query path)** — ingestion is decoupled async pipeline triggered by document upload events; query path is low-latency sync microservices.
+
+### Architecture Diagram
+
+**Ingestion Pipeline:**
+```
+Document Upload (S3 / API)
+    ↓
+Message Queue (Kafka)
+    ↓
+Ingestion Worker
+    ├── Parser (PDF/HTML/DOCX → text)
+    ├── Chunker
+    ├── Embedder (batch)
+    └── Writer
+         ├── Vector DB (embeddings + metadata)
+         └── Metadata Store (doc info, chunk map)
+```
+
+**Query Pipeline:**
+```
+User Query
+    ↓
+Query Service
+    ├── Query Embedder
+    ├── Vector DB (ANN search, top-k)
+    ├── Reranker (cross-encoder)
+    ├── Context Assembler
+    └── LLM (generation)
+         ↓
+    Response + Citations
+```
+
+### Core Components
+| Component | Responsibility |
+|---|---|
+| Parser | Convert raw docs to clean text; preserve structure (headers, tables) |
+| Chunker | Split text into overlapping chunks; attach metadata |
+| Embedder | Convert chunks/queries to vector representations |
+| Vector DB | Store embeddings; ANN search at query time |
+| Metadata Store | Doc registry, chunk map, access control |
+| Reranker | Cross-encoder re-scores top-k retrieved chunks for precision |
+| Context Assembler | Select and order chunks within LLM context window |
+| LLM | Generate grounded answer from assembled context |
+
+### Data Flow
+
+**Ingestion:**
+1. Doc uploaded → event published to Kafka topic `doc.uploaded`
+2. Ingestion worker consumes event → downloads doc from S3
+3. Parser extracts clean text + structure
+4. Chunker splits into 512-token chunks with 50-token overlap
+5. Embedder batches chunks → calls embedding API → returns vectors
+6. Vectors + metadata written to Vector DB and Metadata Store
+
+**Query:**
+1. User query arrives → embed query (cache hit check first)
+2. Vector DB ANN search → top-20 candidate chunks
+3. Optional BM25 keyword search → merge with RRF fusion
+4. Reranker scores all candidates → top-5 kept
+5. Context assembler builds prompt with chunks + citations
+6. LLM generates answer → returned with source links
+
+### Key Design Decisions
+- **Hybrid search (BM25 + vector):** Pure vector search misses exact keyword matches (product codes, names). BM25 + vector fused with RRF handles both semantic and lexical retrieval.
+- **Reranker stage:** ANN search optimizes for recall; cross-encoder reranker optimizes for precision. Two-stage avoids precision/recall tradeoff in one step.
+- **Chunk overlap:** 50-token overlap prevents context loss at boundaries. Tradeoff: 1.5× chunk count.
+- **Event-driven ingestion:** Decouples upload from processing. Ingestion spikes don't affect query latency.
+- **Model Selection:** `text-embedding-3-large` (OpenAI) for quality; `text-embedding-3-small` for cost-sensitive deployments. Reranker: Cohere Rerank or local cross-encoder (BGE).
+
+---
+
+## Low-Level Design
+
+### Data Models
+```
+documents (PostgreSQL):
+  doc_id        UUID      PK
+  tenant_id     UUID
+  source_url    TEXT
+  filename      TEXT
+  doc_type      ENUM (pdf, html, md, docx)
+  status        ENUM (pending, processing, indexed, failed)
+  created_at    TIMESTAMP
+  updated_at    TIMESTAMP
+
+chunks (PostgreSQL):
+  chunk_id      UUID      PK
+  doc_id        UUID      FK → documents
+  chunk_index   INTEGER
+  text          TEXT
+  token_count   INTEGER
+  page_number   INTEGER
+  section       TEXT
+
+vector_index (Vector DB — e.g. Qdrant):
+  id            = chunk_id
+  vector        = float32[1536]
+  payload       = { doc_id, tenant_id, text, page_number, section, created_at }
+```
+
+### API Design
+```
+POST /ingest
+Request:  { "source_url": "s3://...", "doc_type": "pdf", "metadata": {} }
+Response: { "job_id": "...", "status": "queued" }
+
+GET /ingest/{job_id}
+Response: { "status": "indexed", "chunk_count": 48, "doc_id": "..." }
+
+POST /query
+Request:  {
+  "query": "What is our refund policy?",
+  "top_k": 5,
+  "filters": { "doc_type": "pdf", "date_after": "2024-01-01" }
+}
+Response: {
+  "answer": "...",
+  "sources": [{ "doc_id": "...", "chunk_id": "...", "page": 3, "score": 0.94 }]
+}
+
+DELETE /documents/{doc_id}
+Response: { "status": "deleted", "chunks_removed": 48 }
+```
+
+### Component Deep-Dives
+
+#### Chunker
+```
+Document text
+    ↓
+Recursive character splitter
+    ├── Split on: \n\n → \n → sentence → word
+    ├── Target chunk size: 512 tokens
+    └── Overlap: 50 tokens
+    ↓
+Each chunk → attach { doc_id, chunk_index, page_number, section_header }
+```
+
+Semantic chunking (split on meaning boundaries) preferred for structured docs (legal, financial). Fixed-size for unstructured text.
+
+#### Hybrid Search + RRF Fusion
+```
+Query
+  ├── Dense: embed → Vector DB ANN → ranked list A (top-20)
+  └── Sparse: BM25 index → ranked list B (top-20)
+                    ↓
+         RRF score = Σ 1 / (k + rank_i)   where k=60
+                    ↓
+         Merged ranked list → Reranker → top-5
+```
+
+#### Guardrails / Safety Layer
+- **Input:** Max query length (4096 chars); reject if prompt injection pattern detected (`ignore previous instructions`, `jailbreak`, etc.)
+- **Output:** If retrieved context scores below threshold (< 0.7 similarity), return "I don't have enough information" instead of hallucinating
+- **Access control:** `tenant_id` filter on every vector search — users cannot retrieve other tenants' chunks
+- **PII:** Strip PII from query before logging; flag docs with PII for restricted access
+
+### Algorithms & Strategies
+- **Chunking strategy:** Recursive split → 512 tokens → 50-token overlap. Semantic chunking for legal/financial docs.
+- **Embedding model:** `text-embedding-3-large` (1536-dim) for quality; batch at ingest (up to 2048 chunks/call). Cache query embeddings in Redis (TTL: 1hr) — same queries reuse embedding.
+- **ANN indexing:** HNSW in Qdrant. `ef_construction=200, m=16` for quality-speed balance. Full index loaded in memory for latency.
+- **Reranking:** Cohere Rerank API or local `bge-reranker-large`. Input: (query, chunk_text) pairs. Output: relevance score → sort → keep top-5.
+- **Context assembly:** Sort top-5 chunks by page/section order (not relevance score) for coherent reading. Include chunk source metadata for citations. Fit within context window (8K tokens).
+- **Prompt design:** System prompt includes grounding instruction: "Answer ONLY using the provided context. If context is insufficient, say so." Context inserted between `<context>` tags.
+
+### Security Design
+- AuthN/AuthZ: API key → tenant_id resolution; all vector queries scoped to tenant_id
+- Document access: role-based filter in metadata (doc.allowed_roles); checked at context assembly
+- Encryption at rest: S3 (SSE-S3), PostgreSQL (pg_crypto), Vector DB (at-rest encryption)
+- Encryption in transit: TLS 1.3
+- Secrets management: embedding API keys and LLM keys in AWS Secrets Manager
+- PII handling: scan ingested docs for PII (presidio); flag for restricted access or redact before chunking
+
+---
+
+## Observability
+
+### Metrics
+| Metric | Type | Alert threshold |
+|---|---|---|
+| Query latency (p95) | Histogram | > 2s |
+| Retrieval recall@5 | Gauge | < 0.7 (eval set) |
+| Reranker latency | Histogram | > 300ms |
+| Ingestion lag | Gauge | > 10 min |
+| Vector DB ANN latency | Histogram | > 50ms |
+| Cache hit rate (query embed) | Gauge | < 20% |
+
+### Logging
+- Per query: request_id, tenant_id, query_hash (not raw), top_k_doc_ids, reranker_scores, llm_latency, answer_length
+- Per ingestion: doc_id, chunk_count, embed_latency, status
+- Do NOT log: raw query text or doc content (PII risk); log hashes and IDs
+
+### Tracing
+- Trace spans: query_embed → vector_search → rerank → context_assemble → llm_call
+- Useful for: identifying which stage contributes most to latency
+- Sample: 10% normal; 100% on errors or latency > 3s
+
+### Alerting
+| Alert | Threshold | Action |
+|---|---|---|
+| Query latency spike | p95 > 2s for 5min | Page on-call |
+| Ingestion backlog | Queue depth > 1000 for 10min | Scale ingestion workers |
+| Retrieval quality drop | Recall@5 < 0.65 on eval set | Investigate embedding drift |
+| Vector DB memory | > 90% | Add capacity |
+
+---
+
+## Tradeoffs
+
+| Decision | Chose | Sacrificed |
+|---|---|---|
+| ANN over exact NN | ms-latency retrieval | ~2% recall loss (mitigated by reranker) |
+| Reranker stage | Precision | Extra 200ms latency |
+| Hybrid search (BM25 + vector) | Handles keyword + semantic | Two retrieval systems to maintain |
+| Chunk overlap | Boundary coverage | 1.5× storage and embed cost |
+| Event-driven ingestion | Decoupled, scalable | Eventual consistency (5min lag) |
+| Separate vector + metadata store | Query flexibility | Sync complexity on updates/deletes |
+
+---
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| Hallucination | Context insufficient or misleading | Low-similarity fallback: "I don't know"; grounding prompt |
+| Retrieval miss | Poor chunking or embedding model mismatch | Hybrid search (BM25 catches keyword misses) |
+| Context overflow | Too many chunks exceed context window | Rerank → top-5; summarize long chunks |
+| Stale results | Index lag after doc update/delete | Soft-delete chunks on update; async re-embed; invalidate query cache |
+| Embedding model outage | External API down | Fallback to local embedding model (BGE) |
+| Vector DB OOM | Index grew beyond memory | Disk-based HNSW (Qdrant supports); shard index |
+
+---
+
+## Feedback Loop & Improvements
+- User feedback: thumbs up/down per answer → logged with (query_hash, chunk_ids)
+- Low-rated answers trigger: manual review → identify retrieval or generation failure
+- Retrieval improvement: add failing queries to eval set; tune similarity threshold or chunking strategy
+- Eval cadence: run RAGAs (retrieval recall, context precision, answer faithfulness) on golden set per deploy
+- Long-term: use feedback to fine-tune reranker on domain-specific relevance
+
+---
+
+## Interview Tips
+
+### What Interviewers Expect
+- Chunking strategy is first question — answer: recursive split + overlap; semantic chunking for structured docs
+- Two-stage retrieval: ANN for recall → reranker for precision
+- Hybrid search (BM25 + vector) beats pure vector for enterprise knowledge bases
+- Grounding the LLM: system prompt + context injection + "I don't know" fallback
+
+### Common Follow-ups
+- Multi-hop RAG: query requires chaining multiple retrievals — agent-style loop
+- How to handle tables/images in PDFs? → Multimodal embeddings (CLIP) or table-aware parsers
+- Evaluation: RAGAs framework — retrieval recall, context precision, answer faithfulness
+- Scaling Vector DB beyond single node: shard by tenant_id or doc category

--- a/ml-systems/README.md
+++ b/ml-systems/README.md
@@ -1,0 +1,21 @@
+# ML Systems
+
+Machine learning infrastructure and pipeline design.
+
+**Core concerns:** Data freshness, Training/serving skew, Latency vs accuracy, Model drift, Reproducibility
+
+## Cases
+
+| System | Key Challenge |
+|---|---|
+| [Recommendation Engine](./cases/recommendation-engine/) | Real-time vs batch features, cold start, feedback loop |
+| [Fraud Detection](./cases/fraud-detection/) | Low latency inference, imbalanced data, concept drift |
+| [Search Ranking](./cases/search-ranking/) | Feature freshness, A/B testing, multi-stage ranking |
+
+## Patterns
+
+| Pattern | Used In |
+|---|---|
+| [Feature Store](./patterns/feature-store/) | Shared features across models, point-in-time correctness |
+| [Model Serving](./patterns/model-serving/) | Online inference, shadow mode, canary deployments |
+| [Training Pipeline](./patterns/training-pipeline/) | Orchestration, data validation, experiment tracking |


### PR DESCRIPTION
## Summary
- Scaffolds three domain directories: `classical/`, `ml-systems/`, `genai-systems/` with `cases/` and `patterns/` sub-structure
- Adds canonical `TEMPLATE.md` with agreed section order: Requirements → Back-of-Envelope → HLD → LLD → Observability → Tradeoffs → Failure Modes → Feedback Loop → Interview Tips
- Full case writeups for 4 systems: URL Shortener, RAG Pipeline, AI Agent, LLM Gateway — each with scale estimates, HLD/LLD split, observability, tradeoffs, failure modes

## Cases added
| Case | Domain |
|---|---|
| URL Shortener | `classical/` |
| RAG Pipeline | `genai-systems/` |
| AI Agent | `genai-systems/` |
| LLM Gateway | `genai-systems/` |

## Note
Old ML competition files (`Kaggle/`, `DrivenData/`, `AnalyticsVidhya/`, etc.) exist in git history but are missing from the filesystem — not touched in this PR. Handle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)